### PR TITLE
Kyle Reed Added in Presentation topic (Autoencoders)

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -352,7 +352,7 @@ Please use the following table to sign up.
    04/09 |  Kravette, Noah   | Working with NetCDF Data 
    04/09 |  Symula, Sebastian   | Imputation Methods for Missing Data
    04/09 |  Tomaino, Mario Anthony   | K-Prototypes Clustering
-   04/14 |  Reed, Kyle Daniel   | 
+   04/14 |  Reed, Kyle Daniel   | Autoencoders
    04/14 |  Chen, Yifei   | 
    04/14 |  Mundiwala, Mohammad Moiz   | Math animations with manim
    04/16 |  Lin, Selena   | Naive Bayes


### PR DESCRIPTION
Kyle Reed is adding in his intended presentation topic (Autoencoders) for April 14th. Kyle Reed has created a presentation with the main focus being autoencoders that he wishes to present on Monday. The changes in this pull request add "Autoencoders" to my presentation topic in section one. In my presentation, I give an introduction on Autoencoders, and a brief synopsis of neural networks related to Autoencoders, I then talk about what they are and how they work, then I talk about their application, and finally apply it to our NYC Crash dataset.

Thank you,
Kyle Reed